### PR TITLE
Fix decryption instructions when using openssl 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ but we'll take it into consideration for the final evaluation
 
 After getting the key execute:
 
-`openssl aes-256-cbc -d -a -in INSTRUCTIONS.locked -out INSTRUCTIONS.pdf -k [your_key]`
+`openssl aes-256-cbc -d -md md5 -a -in INSTRUCTIONS.locked -out INSTRUCTIONS.pdf -k [your_key]`
 
 Now that you have `INSTRUCTIONS.pdf`, open the file and follow the instructions
 


### PR DESCRIPTION
The problem:
openssl 1.0 has been deprecated because it can be hacked and is not
secure. openssl 1.0 has been removed from most Linux repositories. But
version 1.1.0 uses a new digest, so the command on the README doesn't
work.

The instructions on the README would just output "bad decrypto".

How to fix it:
You can force openssl 1.1.0 to use the (old) md5 hash by adding "-md
md5" to the list of params.